### PR TITLE
Fix small typos and correct URL

### DIFF
--- a/content/about.markdown
+++ b/content/about.markdown
@@ -2,7 +2,7 @@
 title = "About"
 +++
 
-Based in London, the **Quanteda Initiative** is a UK non-profit organization devoted to the promotion of open-source text analysis software. It supports active development of these tools, in addition to providing training materials, training events, and sponsoring workshops and conferences. Its main product is the open-source **quanteda** package for R, but also supports a family of independent but interrelated packages for providing additional functionality for natural language processing and document management.
+Based in London, the **Quanteda Initiative** is a UK non-profit organization devoted to the promotion of open-source text analysis software. It supports active development of these tools, in addition to providing training materials, training events, and sponsoring workshops and conferences. Its main product is the open-source **quanteda** package for R, but the Quanteda Initiative also supports a family of independent but interrelated packages for providing additional functionality for natural language processing and document management.
 
 #### Objectives
 

--- a/content/people.md
+++ b/content/people.md
@@ -29,7 +29,7 @@ id = "people"
               <h4><strong>Kohei Watanabe</strong></h4></a>
               <h5><i>Chief Technology Officer</i> and <i>Director</i></h4>
               <p>
-                I am also an Assistant Professor at Waseda University (Tokyo). I design and write core functions of <a href="https://spacyr.quanteda.io">quanteda</a> and oversee development of other packages for text analysis to make quantitative text analysis more accessible to people from different backgrounds. .
+                I am also an Assistant Professor at Waseda University (Tokyo). I design and write core functions of <a href="https://spacyr.quanteda.io">quanteda</a> and oversee development of other packages for text analysis to make quantitative text analysis more accessible to people from different backgrounds.
               </p>
             </div>
           </div>
@@ -76,7 +76,7 @@ id = "people"
               <h4><strong>Stefan Müller</strong></h4></a>
               <h5><i>Senior Training Advisor</i></h4>
               <p>
-                I work as the editor of the <a href="https://blog.quanteda.org">QI blog</a> and maintain <a href="https://tutorial.quanteda.io">quanteda tutorials</a> and vignettes. As Senior Training Advisor I organize training events on quantitative text analysis. Currently finishing my PhD thesis at Trinity College Dublin, from January 2019, I will be a postdoctoral <a href="https://muellerstefan.net">researcher</a> at the University of Zurich.
+                I work as the editor of the <a href="https://blog.quanteda.org">QI blog</a> and maintain <a href="https://tutorials.quanteda.io">quanteda tutorials</a> and vignettes. As Senior Training Advisor I organize training events on quantitative text analysis. Currently finishing my PhD thesis at Trinity College Dublin, from January 2019, I will be a postdoctoral <a href="https://muellerstefan.net">researcher</a> at the University of Zurich.
               </p>
             </div>
           </div>

--- a/data/testimonials/2.yaml
+++ b/data/testimonials/2.yaml
@@ -1,6 +1,6 @@
 text: >
-  **quanteda** is an excellent resource for both research and teaching than complements R in a way that is invaluable to me — only switching to Python would offer comparable benefits. 
+  **quanteda** is an excellent resource for both research and teaching than complements R in a way that is invaluable to me — only switching to Python would offer comparable benefits.
   It is far superior to related packages (e.g. tm) and so well documented that I use it centrally when teaching text mining.
 name: "Cornelius Puschmann"
-position: "Alexander von Humboldt Institute"
+position: "University of Hamburg"
 avatar: "img/testimonials/cornelius.jpg"


### PR DESCRIPTION
- Adds "the Quanteda Initiative" to the sub-clause of the third sentence
- Updates Cornelius' affiliation
- Corrects typo in Kohei's bio
- Fixes link to tutorials.quanteda.io